### PR TITLE
Patch main to div

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
         
         </header>
 
-        <main class="main_container">
+        <div class="main_container">
 
             <section class= "achievements"> 
                         <img src="images/achievements1.png" class="image_scale"></img> 
@@ -179,7 +179,7 @@
             <section class="expert">
                 
             </section>
-        </main>
+        </div>
 
         <footer>
             

--- a/styles.css
+++ b/styles.css
@@ -135,13 +135,8 @@ body {
 
 .main_container {
     display: flex;
-    justify-content: center;
-    align-content: center;
     flex-direction: column;
-    max-width: 1320px;
-    margin:auto;
-    padding: 20px;
-    flex-shrink: 3;
+    align-items: center;
 }
 
 .headlight {


### PR DESCRIPTION
Replace < main > to < div > and CSS correction of .main_container

- Why? 
< main > intended for logical partition of doc, while we need style partition
 CSS - Because of main container is our main container, it should not implement exactly styles of blocks properties (like width or padding). Instead every block have to be styled by its own..
 